### PR TITLE
[TECHNICAL-SUPPORT] LPS-71385

### DIFF
--- a/dynamic-data-mapping-taglib/src/main/resources/META-INF/resources/template_selector/page.jsp
+++ b/dynamic-data-mapping-taglib/src/main/resources/META-INF/resources/template_selector/page.jsp
@@ -68,13 +68,21 @@ Group ddmTemplateGroup = GroupLocalServiceUtil.getGroup(ddmTemplateGroupId);
 
 </aui:select>
 
-<liferay-ui:icon
-	iconCssClass="<%= icon %>"
-	id="selectDDMTemplate"
-	label="<%= true %>"
-	message='<%= LanguageUtil.format(resourceBundle, "manage-display-templates-for-x", HtmlUtil.escape(ddmTemplateGroup.getDescriptiveName(locale)), false) %>'
-	url="javascript:;"
-/>
+<%
+if (!ddmTemplateGroup.isLayoutPrototype()) {
+%>
+
+	<liferay-ui:icon
+		iconCssClass="<%= icon %>"
+		id="selectDDMTemplate"
+		label="<%= true %>"
+		message='<%= LanguageUtil.format(resourceBundle, "manage-display-templates-for-x", HtmlUtil.escape(ddmTemplateGroup.getDescriptiveName(locale)), false) %>'
+		url="javascript:;"
+	/>
+
+<%
+}
+%>
 
 <liferay-portlet:renderURL plid="<%= themeDisplay.getPlid() %>" portletName="<%= PortletProviderUtil.getPortletId(DDMTemplate.class.getName(), PortletProvider.Action.VIEW) %>" var="basePortletURL">
 	<portlet:param name="showHeader" value="<%= Boolean.FALSE.toString() %>" />


### PR DESCRIPTION
/cc @moltam89 @jonathanmccann @SamZiemer

Relevant tickets:

https://issues.liferay.com/browse/LPP-24582
https://issues.liferay.com/browse/LPS-71385

As per [the comments on the LPS](https://issues.liferay.com/browse/LPS-71385?focusedCommentId=1001306&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-1001306), the correct behavior is for Page Templates not to allow ADT's to be created directly from them. This change just hides the "Manage Display Templates for (Page Template)" button.

For notes from the previous set of changes, please see https://github.com/ealonso/liferay-portal/pull/848 and https://github.com/liferay/com-liferay-dynamic-data-mapping/pull/98.

Thank you!